### PR TITLE
generating openapi swagger doc out of OpenAPI yaml file

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,25 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - name: Generate Swagger UI
+        uses: Legion2/swagger-ui-action@v1.1.6
+        with:
+          spec-file: ./openapi.yml
+          output: ./swagger-docs
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3.9.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: swagger-docs
+          publish_branch: gh-pages


### PR DESCRIPTION
- generate a [swagger doc](https://cdcgov.github.io/data-exchange-api-examples/) based on the output from gh-pages branch.
- chase's #2 must go in first before this works