### PR TITLE
update for v2 metadata fields

### DIFF
--- a/tus-clients/browser-multi-files/demo.js
+++ b/tus-clients/browser-multi-files/demo.js
@@ -125,19 +125,19 @@
       let prevFileBytesUploaded = 0
 
       const metadata = {
-        // REQUIRED
-        meta_destination_id: "dextesting", // final container destination: dextesting-testevent1,
-        meta_ext_event: "testevent1",
-  
-        // REQUIRED: original file name, see metadata for destination file repo
-        filename: file.name, 
-  
-        // CUSTOM (PER USE_CASE) see metadata for destination file in repo
-        meta_file_timestamp: file.lastModified,
-        meta_ext_objectkey: crypto.randomUUID(), 
-        filetype: "text/plain",
-        meta_ext_source: "for_the_demo",
-        meta_username: "example@cdc.gov",
+      // DEX Metadata Fields - version 2 sender manifest
+      version: "2.0",
+      data_stream_id: "data stream id value here",
+      data_stream_route: "data stream route value here",
+      sender_id: "sender id value here",
+      data_producer_id: "data producer id value here",
+      jurisdiction: "jurisdiction value here",
+      received_filename: "uploaded file name here"
+
+      // Custom Metadata Fields - varies by data stream; optional
+      //custom_field_1: "allowed custom field value",
+      //custom_field_2: "allowed custom field value"
+
       } // .metadata
 
       const options = {

--- a/tus-clients/browser/demo.js
+++ b/tus-clients/browser/demo.js
@@ -111,21 +111,18 @@ function startUpload () {
 
   const metadata =   {
 
-    // REQUIRED
-    meta_destination_id: "dextesting", // final container destination: dextesting-testevent1,
-    meta_ext_event: "testevent1",
+    // DEX Metadata Fields - version 2 sender manifest
+    version: "2.0",
+    data_stream_id: "data stream id value here",
+    data_stream_route: "data stream route value here",
+    sender_id: "sender id value here",
+    data_producer_id: "data producer id value here",
+    jurisdiction: "jurisdiction value here",
+    received_filename: "uploaded file name here"
 
-    // one of these 3 fields is needed to have the original file name 
-    filename: fileNameUpload, // OR
-    meta_ext_filename: fileNameUpload, // OR 
-    // original_filename: fileNameUpload, 
-
-    // CUSTOM PER USE_CASE
-    meta_file_timestamp: file.lastModified,
-    meta_ext_objectkey: uuidv4ID, 
-    filetype: "text/plain",
-    meta_ext_source: "for_the_demo",
-    meta_username: "example@cdc.gov",
+    // Custom Metadata Fields - varies by data stream; optional
+    //custom_field_1: "allowed custom field value",
+    //custom_field_2: "allowed custom field value"
 
   } // .metadata
 

--- a/tus-clients/nodejs/index.js
+++ b/tus-clients/nodejs/index.js
@@ -13,7 +13,7 @@ async function start() {
     process.exit(1);
   }
 
-  const path = `${__dirname}/../../upload-files/10MB-test-file`;
+  const path = `${__dirname}/../../upload-files/upload test file here`;
   const file = fs.createReadStream(path);
 
   const options = {
@@ -22,17 +22,18 @@ async function start() {
       Authorization: `Bearer ${loginResponse.access_token}`,
     },
     metadata: {
-      filename: "10MB-test-file",
-      filetype: "text/plain",
-      meta_destination_id: "ndlp",
-      meta_ext_event: "routineImmunization",
-      meta_ext_source: "IZGW",
-      meta_ext_sourceversion: "V2022-12-31",
-      meta_ext_entity: "DD2",
-      meta_username: "ygj6@cdc.gov",
-      meta_ext_objectkey: uuidv4(),
-      meta_ext_filename: "10MB-test-file",
-      meta_ext_submissionperiod: '1',
+      // DEX Metadata Fields - version 2 sender manifest
+      version: "2.0",
+      data_stream_id: "data stream id value here",
+      data_stream_route: "data stream route value here",
+      sender_id: "sender id value here",
+      data_producer_id: "data producer id value here",
+      jurisdiction: "jurisdiction value here",
+      received_filename: "uploaded file name here"
+
+      // Custom Metadata Fields - varies by data stream; optional
+      //custom_field_1: "allowed custom field value",
+      //custom_field_2: "allowed custom field value"
     },
     onError(error) {
       console.error("An error occurred:");

--- a/tus-clients/python/tuspy-uploader-test.py
+++ b/tus-clients/python/tuspy-uploader-test.py
@@ -69,20 +69,23 @@ try:
         headers={'Authorization':'Bearer ' + ACCESS_TOKEN}
     )
 
-    filename = '10MB-test-file'
+    filename = 'test upload file name here'
     # create the uploader
     uploader = my_client.uploader('../../upload-files/{0}'.format(filename),
         metadata={
-            'filename':filename,
-            'meta_destination_id':'ndlp',
-            'meta_ext_event':'routineImmunization',
-            'meta_ext_source':'IZGW',
-            'meta_ext_sourceversion':'V2022-12-31',
-            'meta_ext_entity':'DD2',
-            'meta_username':'ygj6@cdc.gov',
-            'meta_ext_objectkey':str(uuid.uuid4()),
-            'meta_ext_filename':filename, 
-            'meta_ext_submissionperiod': '1',
+            # DEX Metadata Fields - version 2 sender manifest
+            'version':'2.0',
+            'data_stream_id':'data stream id value here',
+            'data_stream_route':'data stream route value here',
+            'sender_id':'sender id value here',
+            'data_producer_id':'data producer id value here',
+            'jurisdiction':'jurisdiction value here',
+            'received_filename':'uploaded file name here'
+
+            # Custom Metadata Fields - varies by data stream; optional
+            #'custom_field_1':'allowed custom field value',
+            #'custom_field_2':'allowed custom field value'
+
             }
         )
 


### PR DESCRIPTION
## Updates

- Python client - updated file name to be more generic; updated sample metadata fields to include DEX v2 sender manifest fields
- Node client - updated sample metadata fields to include DEX v2 sender manifest fields
- Browser client - updated sample metadata fields to include DEX v2 sender manifest fields
- Browser multi-client - updated sample metadata fields to include DEX v2 sender manifest fields